### PR TITLE
Fix heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rf24server
+# rf24drone
 
 A C++ ground base station program for communicating with NRF24L01+ drones over RF.  
 Built with modular CMake structure and supports automatic leader selection, telemetry polling, and debug printing.


### PR DESCRIPTION
## Summary
- rename project heading to rf24drone

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f43c1f8588326918f9ec1776e2cd8