### PR TITLE
Replace gbs_program with drone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cmake ..
 make
 ```
 
-This will generate the executable `gbs_program` in the `build/` directory.
+This will generate the executable `drone` in the `build/` directory.
 
 ### 3. (Optional) Symlink compile_commands.json
 
@@ -62,13 +62,13 @@ ln -sf build/compile_commands.json .
 From the build folder:
 
 ```bash
-./gbs_program
+./drone
 ```
 
 Or from the root:
 
 ```bash
-./build/gbs_program
+./build/drone
 ```
 
 ---


### PR DESCRIPTION
## Summary
- update README references from `gbs_program` to `drone`

## Testing
- `make test` *(fails: No rule to make target)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_683f43bd0d708326b8815090f81c8ddc