### PR TITLE
Implement queue-based packet system

### DIFF
--- a/currentDrone.md
+++ b/currentDrone.md
@@ -105,6 +105,13 @@ Bu sistem, nRF24L01 donanımıyla çalışan, kimliği atanmış droneların:
   - RX boşalana kadar beklenir
   - Sonra TX yapılır ve RX tekrar açılır
 
+## 📨 Telemetri Gönderim İzni
+
+- Tam çift yönlü haberleşme imkanımız olmadığından,
+  drone'lar telemetri paketlerini ancak yer istasyonundan
+  gelen `PermissionToSend` paketinden sonra yollar.
+- Bu mekanizma TX/RX çakışmasını önler.
+
 ---
 
 ## ❌ Bilinçli Olarak Eklenmeyenler

--- a/include/drone.hpp
+++ b/include/drone.hpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <iostream>
 #include <optional>
+#include <queue>
 #include <string>
+#include <array>
 
 class Drone {
 public:
@@ -31,6 +33,15 @@ public:
   void printDroneInfo() const;
 
 private:
+  struct RawPacket {
+    PacketType type;
+    std::array<uint8_t, 32> data{};
+    size_t size = 0;
+  };
+
+  size_t packetSize(PacketType type) const;
+  void pollRadio();
+
   RadioInterface &radio;
   DroneIdType temp_id_;
   std::optional<DroneIdType> network_id_;
@@ -38,6 +49,7 @@ private:
   bool has_permission_to_send_ = false;
   std::string name_;
   TelemetryPacket telemetry;
+  std::queue<RawPacket> rx_queue_;
 
   void handleCommand(const CommandPacket &cmd);
 };


### PR DESCRIPTION
## Summary
- add telemetry permission mention in docs
- process incoming RF packets via FIFO queue
- filter commands by target ID & delay

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683f602c74188326a6dfa3e8e0f6a67d