### PR TITLE
Support channel switch from join response

### DIFF
--- a/currentDrone.md
+++ b/currentDrone.md
@@ -15,8 +15,8 @@ Bu sistem, nRF24L01 donanımıyla çalışan, kimliği atanmış droneların:
 
 | Kanal     | Amaç                                     |
 |-----------|------------------------------------------|
-| Channel 0 | Yer istasyonu iletişimi (ID, sensör uplink, liderlik) |
-| Channel 1 | Drone ↔ Drone iletişimi (komut yayını, heartbeat)     |
+| Channel 1 | Başlangıç (Join) kanalı |
+| Atanan Kanal | Drone iletişimi ve sensör uplink |
 
 ---
 
@@ -33,16 +33,16 @@ Bu sistem, nRF24L01 donanımıyla çalışan, kimliği atanmış droneların:
 
 ## 🧠 Davranış Akışı
 
-1. Drone `Channel 0` üzerinden yer istasyonuna `JoinRequest` yollar
+1. Drone varsayılan `Channel 1` üzerinden yer istasyonuna `JoinRequest` yollar
 2. Yer istasyonu:
-   - `JoinResponse` (drone_id + leader_id) yollar
-3. Drone `Channel 1`’e geçer ve ana döngü başlar:
+   - `JoinResponse` (drone_id + leader_id + channel) yollar
+3. Drone verilen kanala (`JoinResponse.channel`) geçer ve ana döngü başlar:
    - RF'den paket toplar (`rxQueue`)
    - Komut varsa:
      - Eğer `target_id == drone_id` ve `gecikme ≤ 3000ms` ise uygular
      - Eğer `next_leader_id` içeriyorsa lider güncellenir
      - Eğer liderse, yer istasyonundan gelen komutları yayınlar
-   - Belirli aralıklarla sensör verisi gönderilir (`Channel 0`)
+   - Belirli aralıklarla sensör verisi gönderilir (atanan kanal)
    - 5 saniyeden uzun süre lider mesajı gelmezse:
      - `leader_id = std::nullopt`
      - Yer istasyonuna `LeaderRequest` gönderilir
@@ -52,7 +52,7 @@ Bu sistem, nRF24L01 donanımıyla çalışan, kimliği atanmış droneların:
 ## 📦 Paket Tipleri (`PacketType`)
 
 - `JoinRequest`
-- `JoinResponse { drone_id, leader_id }`
+- `JoinResponse { drone_id, leader_id, channel }`
 - `CommandPacket { target_id, command, payload, timestamp, next_leader_id? }`
 - `SensorPacket`
 - `Heartbeat`

--- a/include/packets.hpp
+++ b/include/packets.hpp
@@ -56,6 +56,7 @@ struct JoinResponsePacket {
   PacketType type = PacketType::JOIN_RESPONSE;
   DroneIdType assigned_id;
   DroneIdType current_leader_id;
+  uint8_t assigned_channel;
   uint32_t timestamp;
 };
 
@@ -90,7 +91,7 @@ static_assert(sizeof(LeaderAnnouncementPacket) == 6,
 
 static_assert(sizeof(HeartbeatPacket) == 6, "HeartbeatPacket size mismatch");
 
-static_assert(sizeof(JoinResponsePacket) == 7,
+static_assert(sizeof(JoinResponsePacket) == 8,
               "JoinResponsePacket boyutu hatalı");
 
 static_assert(sizeof(JoinRequestPacket) == 26,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main() {
   }
 
   // --- Katılma Aşaması ---
-  radio.configure(0, RadioDataRate::MEDIUM_RATE);
+  radio.configure(1, RadioDataRate::MEDIUM_RATE);
   radio.setAddress(BASE_TX, BASE_RX);
 
   Drone drone(radio);
@@ -51,11 +51,13 @@ int main() {
 
   drone.setNetworkId(resp.assigned_id);
   DroneIdType leader_id = resp.current_leader_id;
+  uint8_t op_channel = resp.assigned_channel;
   std::cout << "Ağ ID: " << static_cast<int>(resp.assigned_id)
-            << " Lider: " << static_cast<int>(leader_id) << std::endl;
+            << " Lider: " << static_cast<int>(leader_id)
+            << " Kanal: " << static_cast<int>(op_channel) << std::endl;
 
   // --- Operasyon Aşaması ---
-  radio.configure(1, RadioDataRate::MEDIUM_RATE);
+  radio.configure(op_channel, RadioDataRate::MEDIUM_RATE);
   radio.setAddress(BASE_TX, BASE_RX);
 
   auto last_leader = std::chrono::steady_clock::now();
@@ -82,9 +84,7 @@ int main() {
                           static_cast<int16_t>(rand() % 50),
                           static_cast<int16_t>(rand() % 50),
                           static_cast<int16_t>(rand() % 50), 120.0f, 3.7f);
-      radio.configure(0, RadioDataRate::MEDIUM_RATE);
       drone.sendTelemetry();
-      radio.configure(1, RadioDataRate::MEDIUM_RATE);
       last_telemetry = now;
     }
 
@@ -92,9 +92,7 @@ int main() {
       LeaderRequestPacket req{};
       req.drone_id = drone.getNetworkId().value_or(drone.getTempId());
       req.timestamp = static_cast<uint32_t>(std::time(nullptr));
-      radio.configure(0, RadioDataRate::MEDIUM_RATE);
       radio.send(&req, sizeof(req));
-      radio.configure(1, RadioDataRate::MEDIUM_RATE);
       last_leader = now;
     }
 


### PR DESCRIPTION
## Summary
- include desired RF channel in `JoinResponsePacket`
- join on channel 1 then switch to assigned channel
- clean up channel toggling in `main.cpp`
- document new join and channel behaviour

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68407e72743883269877e81bda287269