### PR TITLE
Add full duplex radio support

### DIFF
--- a/include/radio.hpp
+++ b/include/radio.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <memory>
 
 enum class RadioDataRate {
   LOW_RATE,
@@ -14,9 +15,14 @@ enum class RadioDataRate {
 
 class RadioInterface {
 public:
-  RadioInterface(uint8_t cePin, uint8_t csnPin); // for default SPI BUS
-  RadioInterface(uint8_t cePin, uint8_t csnPin,
-                 uint8_t spiPort); // for custom SPI BUS
+  // Single transceiver constructor
+  RadioInterface(uint8_t cePin, uint8_t csnPin);
+
+  // Full duplex constructors (separate TX and RX modules)
+  RadioInterface(uint8_t txCePin, uint8_t txCsnPin, uint8_t rxCePin,
+                 uint8_t rxCsnPin);
+  RadioInterface(uint8_t txCePin, uint8_t txCsnPin, uint8_t txSpiPort,
+                 uint8_t rxCePin, uint8_t rxCsnPin, uint8_t rxSpiPort);
 
   bool begin();
   void setAddress(uint64_t tx, uint64_t rx);
@@ -31,7 +37,9 @@ public:
   uint8_t getARC();
 
 private:
-  RF24 radio;
+  std::unique_ptr<RF24> tx_radio;
+  std::unique_ptr<RF24> rx_radio; // if null, single transceiver mode
+  bool full_duplex = false;
   uint64_t tx_address = 0;
   uint64_t rx_address = 0;
   // Holds the latest packet when it was peeked so that it can be

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,14 +8,16 @@
 #include <iostream>
 #include <thread>
 
-#define CE_PIN 27
-#define CSN_PIN 10
+#define TX_CE_PIN 27
+#define TX_CSN_PIN 10
+#define RX_CE_PIN 22
+#define RX_CSN_PIN 0
 
 static constexpr uint64_t BASE_TX = 0xF0F0F0F0D2LL;
 static constexpr uint64_t BASE_RX = 0xF0F0F0F0E1LL;
 
 int main() {
-  RadioInterface radio(CE_PIN, CSN_PIN);
+  RadioInterface radio(TX_CE_PIN, TX_CSN_PIN, RX_CE_PIN, RX_CSN_PIN);
 
   if (!radio.begin()) {
     std::cerr << "Radio başlatılamadı!\n";

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -4,69 +4,106 @@
 #include <iostream>
 
 RadioInterface::RadioInterface(uint8_t cePin, uint8_t csnPin)
-    : radio(cePin, csnPin) {}
+    : tx_radio(std::make_unique<RF24>(cePin, csnPin)) {}
 
-RadioInterface::RadioInterface(uint8_t cePin, uint8_t csnPin, uint8_t spiPort)
-    : radio(cePin, csnPin, spiPort) {}
+
+RadioInterface::RadioInterface(uint8_t txCePin, uint8_t txCsnPin, uint8_t rxCePin,
+                               uint8_t rxCsnPin)
+    : tx_radio(std::make_unique<RF24>(txCePin, txCsnPin)),
+      rx_radio(std::make_unique<RF24>(rxCePin, rxCsnPin)), full_duplex(true) {}
+
+RadioInterface::RadioInterface(uint8_t txCePin, uint8_t txCsnPin,
+                               uint8_t txSpiPort, uint8_t rxCePin,
+                               uint8_t rxCsnPin, uint8_t rxSpiPort)
+    : tx_radio(std::make_unique<RF24>(txCePin, txCsnPin, txSpiPort)),
+      rx_radio(std::make_unique<RF24>(rxCePin, rxCsnPin, rxSpiPort)),
+      full_duplex(true) {}
 
 bool RadioInterface::begin() {
-  if (!radio.begin())
+  if (!tx_radio->begin())
     return false;
-  radio.setPALevel(RF24_PA_LOW);
-  radio.stopListening();
+  tx_radio->setPALevel(RF24_PA_LOW);
+  if (full_duplex && rx_radio) {
+    if (!rx_radio->begin())
+      return false;
+    rx_radio->setPALevel(RF24_PA_LOW);
+    rx_radio->startListening();
+  } else {
+    tx_radio->stopListening();
+  }
   return true;
 }
 
 void RadioInterface::setAddress(uint64_t tx, uint64_t rx) {
   tx_address = tx;
   rx_address = rx;
-  radio.openWritingPipe(tx_address);
-  radio.openReadingPipe(1, rx_address);
+  tx_radio->openWritingPipe(tx_address);
+  if (full_duplex && rx_radio)
+    rx_radio->openReadingPipe(1, rx_address);
+  else
+    tx_radio->openReadingPipe(1, rx_address);
 }
 
 void RadioInterface::openListeningPipe(uint8_t pipe, uint64_t address) {
-  radio.openReadingPipe(pipe, address);
+  if (full_duplex && rx_radio)
+    rx_radio->openReadingPipe(pipe, address);
+  else
+    tx_radio->openReadingPipe(pipe, address);
 }
 
 void RadioInterface::configure(uint8_t channel, RadioDataRate datarate) {
-  radio.setChannel(channel);
-  switch (datarate) {
-  case RadioDataRate::LOW_RATE:
-    radio.setDataRate(RF24_250KBPS);
-    break;
-  case RadioDataRate::MEDIUM_RATE:
-    radio.setDataRate(RF24_1MBPS);
-    break;
-  case RadioDataRate::HIGH_RATE:
-    radio.setDataRate(RF24_2MBPS);
-    break;
+  auto configureRadio = [&](RF24 *r) {
+    r->setChannel(channel);
+    switch (datarate) {
+    case RadioDataRate::LOW_RATE:
+      r->setDataRate(RF24_250KBPS);
+      break;
+    case RadioDataRate::MEDIUM_RATE:
+      r->setDataRate(RF24_1MBPS);
+      break;
+    case RadioDataRate::HIGH_RATE:
+      r->setDataRate(RF24_2MBPS);
+      break;
+    }
+    r->setAutoAck(true);
+    r->enableDynamicPayloads();
+    r->enableAckPayload();
+  };
+
+  configureRadio(tx_radio.get());
+  if (full_duplex && rx_radio) {
+    configureRadio(rx_radio.get());
+    rx_radio->startListening();
+  } else {
+    tx_radio->startListening();
   }
-  radio.setAutoAck(true);
-  radio.enableDynamicPayloads();
-  radio.enableAckPayload();
-  radio.startListening();
 }
 
 bool RadioInterface::send(const void *data, size_t size) {
-  radio.stopListening();
-  bool success = radio.write(data, static_cast<uint8_t>(size));
-  radio.startListening();
+  if (full_duplex && rx_radio) {
+    return tx_radio->write(data, static_cast<uint8_t>(size));
+  }
+  tx_radio->stopListening();
+  bool success = tx_radio->write(data, static_cast<uint8_t>(size));
+  tx_radio->startListening();
   return success;
 }
 
 bool RadioInterface::receive(void *data, size_t size, bool peekOnly) {
+  RF24 *rx = (full_duplex && rx_radio) ? rx_radio.get() : tx_radio.get();
+
   if (peekOnly) {
     if (cached_packet) {
       std::memcpy(data, cached_packet->data(), size);
       return true;
     }
 
-    if (!radio.available())
+    if (!rx->available())
       return false;
 
     cached_packet.emplace();
-    radio.read(cached_packet->data(),
-               static_cast<uint8_t>(cached_packet->size()));
+    rx->read(cached_packet->data(),
+             static_cast<uint8_t>(cached_packet->size()));
     std::memcpy(data, cached_packet->data(), size);
     return true;
   }
@@ -77,20 +114,21 @@ bool RadioInterface::receive(void *data, size_t size, bool peekOnly) {
     return true;
   }
 
-  if (!radio.available())
+  if (!rx->available())
     return false;
 
   std::array<uint8_t, 32> buffer{};
-  radio.read(buffer.data(), buffer.size());
+  rx->read(buffer.data(), buffer.size());
   std::memcpy(data, buffer.data(), size);
   cached_packet.reset();
   return true;
 }
 
 bool RadioInterface::testRPD() {
-  return radio.testRPD();
+  RF24 *rx = (full_duplex && rx_radio) ? rx_radio.get() : tx_radio.get();
+  return rx->testRPD();
 }
 
 uint8_t RadioInterface::getARC() {
-  return radio.getARC();
+  return tx_radio->getARC();
 }


### PR DESCRIPTION
## Summary
- support two NRF modules for TX and RX in `RadioInterface`
- add new constructors using separate pins
- update main to demonstrate full-duplex setup
- drop the unused `RadioInterface(uint8_t, uint8_t, uint8_t)` constructor

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./drone` *(fails: SPIException: Can't open device /dev/spidev1.0)*


------
https://chatgpt.com/codex/tasks/task_e_684092c112a48326b34a8328dd7321bf