### PR TITLE
Add convenience symlink and separate test output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,18 @@ add_subdirectory(external/RF24)
 # --- YENİ EKLENEN BÖLÜM SONU ---
 
 # src altındaki tüm cpp dosyalarını al
-file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
-    ${CMAKE_SOURCE_DIR}/src/*.cpp
+add_library(drone_core
+    src/drone.cpp
+    src/radio.cpp
 )
 
-add_executable(drone ${SRC_FILES})
+add_executable(drone src/main.cpp)
+
+target_include_directories(drone_core
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/external/RF24
+)
 
 target_include_directories(drone
     PRIVATE
@@ -40,7 +47,8 @@ target_include_directories(drone
 # --- YENİ target_link_libraries SATIRI ---
 # drone hedefini, submodule tarafından oluşturulan rf24 hedefine bağla
 # (RF24'ün CMake hedef adının "rf24" olduğunu varsayıyoruz)
-target_link_libraries(drone PRIVATE rf24)
+target_link_libraries(drone_core PUBLIC rf24)
+target_link_libraries(drone PRIVATE drone_core)
 # --- YENİ target_link_libraries SATIRI SONU ---
 
 # compile_commands.json symlink
@@ -56,4 +64,21 @@ add_custom_target(run
     COMMAND drone
  DEPENDS drone
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
+# Place test executables under the project root in a `test` directory
+file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
+
+add_executable(duplex_test duplex_test.cpp)
+target_link_libraries(duplex_test PRIVATE drone_core)
+set_target_properties(duplex_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/test
+)
+
+# Symlink the main binary to the project root for convenience
+add_custom_command(
+    TARGET drone POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            $<TARGET_FILE:drone>
+            ${CMAKE_SOURCE_DIR}/drone
 )

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ cmake ..
 make
 ```
 
-This will generate the executable `drone` in the `build/` directory.
+This will generate the executable `drone` in the `build/` directory and
+create a symlink `./drone` at the project root for convenience. Test
+executables are placed under `test/`.
 
 ### 3. (Optional) Symlink compile_commands.json
 
@@ -60,16 +62,16 @@ ln -sf build/compile_commands.json .
 
 ## 🧪 Running the Program
 
-From the build folder:
+From either the build directory or the project root (via the symlink):
 
 ```bash
 ./drone
 ```
 
-Or from the root:
+The test binary can be run from the `test/` folder:
 
 ```bash
-./build/drone
+./test/duplex_test
 ```
 
 ---

--- a/duplex_test.cpp
+++ b/duplex_test.cpp
@@ -1,0 +1,54 @@
+#include "radio.hpp"
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <thread>
+
+// Pin definitions for two drones (adjust to your wiring)
+#define DRONE_A_TX_CE 27
+#define DRONE_A_TX_CSN 10
+#define DRONE_A_RX_CE 22
+#define DRONE_A_RX_CSN 0
+
+#define DRONE_B_TX_CE 17
+#define DRONE_B_TX_CSN 0
+#define DRONE_B_RX_CE 23
+#define DRONE_B_RX_CSN 1
+
+static constexpr uint64_t ADDR_A_TX = 0xF0F0F0F0AAULL;
+static constexpr uint64_t ADDR_B_TX = 0xF0F0F0F0BBULL;
+
+void droneThread(RadioInterface &radio, const char *sendMsg) {
+  char buffer[32]{};
+  for (int i = 0; i < 3; ++i) {
+    radio.send(sendMsg, std::strlen(sendMsg) + 1);
+    if (radio.receive(buffer, sizeof(buffer))) {
+      std::cout << sendMsg << " received: " << buffer << std::endl;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+}
+
+int main() {
+  RadioInterface radioA(DRONE_A_TX_CE, DRONE_A_TX_CSN, DRONE_A_RX_CE, DRONE_A_RX_CSN);
+  RadioInterface radioB(DRONE_B_TX_CE, DRONE_B_TX_CSN, DRONE_B_RX_CE, DRONE_B_RX_CSN);
+
+  if (!radioA.begin() || !radioB.begin()) {
+    std::cerr << "Failed to initialize radios" << std::endl;
+    return 1;
+  }
+
+  radioA.configure(90, RadioDataRate::MEDIUM_RATE);
+  radioB.configure(90, RadioDataRate::MEDIUM_RATE);
+  radioA.setAddress(ADDR_A_TX, ADDR_B_TX);
+  radioB.setAddress(ADDR_B_TX, ADDR_A_TX);
+
+  std::thread ta(droneThread, std::ref(radioA), "DroneA");
+  std::thread tb(droneThread, std::ref(radioB), "DroneB");
+
+  ta.join();
+  tb.join();
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- make duplex test output to a `test/` directory
- symlink the main `drone` executable to project root
- document new build and run steps

## Testing
- `cmake ..`
- `make -j2`
- `./test/duplex_test` *(fails: Can't open device /dev/spidev1.0)*

------
https://chatgpt.com/codex/tasks/task_e_684199c503788326a8bde0bc0ea00a67