### PR TITLE
Handle dynamic leader changes

### DIFF
--- a/include/drone.hpp
+++ b/include/drone.hpp
@@ -19,6 +19,11 @@ public:
   bool isLeader() const;
   const std::string &getName() const;
 
+  std::optional<DroneIdType> getCurrentLeaderId() const;
+  void setCurrentLeaderId(std::optional<DroneIdType> id);
+  bool hasRoleChanged() const;
+  void clearRoleChanged();
+
   void setNetworkId(DroneIdType net_id);
   void clearNetworkId();
   void setLeaderStatus(bool status);
@@ -52,6 +57,11 @@ private:
   uint32_t total_sends_ = 0;
   uint32_t failed_sends_ = 0;
   std::queue<RawPacket> rx_queue_;
+
+  std::optional<DroneIdType> current_leader_id_;
+  bool role_changed_ = false;
+
+  void handleLeaderAnnouncement(const LeaderAnnouncementPacket &ann);
 
   void handleCommand(const CommandPacket &cmd);
 };


### PR DESCRIPTION
## Summary
- add fields and helpers to `Drone` for leader announcements
- process `LEADER_ANNOUNCEMENT` packets and flip role
- restructure `main` with `leaderLoop`/`followerLoop` switching
- allow drone to exit leader mode when another leader is announced

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68419a4968e083269cc43f313d7d7e5d