### PR TITLE
Add MPU6050 terminal example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,13 @@ set_target_properties(packets_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/test
 )
 
+# Example: read MPU6050 data and print to the terminal
+add_executable(mpu_terminal examples/mpu_terminal.cpp)
+target_link_libraries(mpu_terminal PRIVATE drone_core)
+set_target_properties(mpu_terminal PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+)
+
 # Symlink the main binary to the project root for convenience
 add_custom_command(
     TARGET drone POST_BUILD

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ The test binary can be run from the `test/` folder:
 ./test/duplex_test
 ```
 
+### Reading raw MPU6050 data
+
+An extra example is provided to print sensor values over I2C:
+
+```bash
+make mpu_terminal
+./examples/mpu_terminal
+```
+
 ---
 
 ## 💡 Features

--- a/examples/mpu_terminal.cpp
+++ b/examples/mpu_terminal.cpp
@@ -1,0 +1,28 @@
+#include "mpu6050.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+int main() {
+    Mpu6050 sensor;
+    if (!sensor.init()) {
+        std::cerr << "Failed to initialize MPU6050" << std::endl;
+        return 1;
+    }
+
+    std::cout << "MPU6050 initialized. Reading data..." << std::endl;
+    while (true) {
+        int16_t ax, ay, az;
+        int16_t gx, gy, gz;
+        if (sensor.readAcceleration(ax, ay, az) && sensor.readGyro(gx, gy, gz)) {
+            std::cout << "AX: " << ax << " AY: " << ay << " AZ: " << az
+                      << " | GX: " << gx << " GY: " << gy << " GZ: " << gz
+                      << std::endl;
+        } else {
+            std::cerr << "Sensor read error" << std::endl;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide a simple example to read MPU6050 sensor values over I2C
- compile `mpu_terminal` in CMake
- document the example in the README

## Testing
- `cmake .. && make -j4 mpu_terminal`

------
https://chatgpt.com/codex/tasks/task_e_6856bf51333483269bcaec3f0262a11c