### PR TITLE
Add telemetry receive test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,14 @@ set_target_properties(mpu_send_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/test
 )
 
+# Companion test that receives the telemetry packets sent by
+# `mpu_send_test` and prints them to the console.
+add_executable(mpu_receive_test mpu_receive_test.cpp)
+target_link_libraries(mpu_receive_test PRIVATE drone_core)
+set_target_properties(mpu_receive_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/test
+)
+
 # Example: read MPU6050 data and print to the terminal
 add_executable(mpu_terminal examples/mpu_terminal.cpp)
 target_link_libraries(mpu_terminal PRIVATE drone_core)

--- a/mpu_receive_test.cpp
+++ b/mpu_receive_test.cpp
@@ -1,0 +1,41 @@
+#include "radio.hpp"
+#include "packets.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#define RX_CE_PIN 22
+#define RX_CSN_PIN 10
+
+static constexpr uint64_t BASE_TX = 0xF0F0F0F0E1LL;
+static constexpr uint64_t BASE_RX = 0xF0F0F0F0D2LL;
+
+int main() {
+    RadioInterface radio(RX_CE_PIN, RX_CSN_PIN);
+    if (!radio.begin()) {
+        std::cerr << "Radio init failed" << std::endl;
+        return 1;
+    }
+
+    radio.configure(1, RadioDataRate::MEDIUM_RATE);
+    radio.setAddress(BASE_TX, BASE_RX);
+
+    std::cout << "Waiting for telemetry packets..." << std::endl;
+    for (int i = 0; i < 10; ++i) {
+        PacketType type;
+        if (radio.receive(&type, sizeof(type), true) && type == PacketType::TELEMETRY) {
+            TelemetryPacket packet{};
+            if (radio.receive(&packet, sizeof(packet))) {
+                std::cout << "Accel: " << packet.acceleration_x << ',' << packet.acceleration_y
+                          << ',' << packet.acceleration_z
+                          << " Gyro: " << packet.gyroscope_x << ',' << packet.gyroscope_y
+                          << ',' << packet.gyroscope_z
+                          << " Altitude: " << packet.altitude
+                          << " Battery: " << packet.battery_voltage
+                          << std::endl;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `mpu_receive_test` example to read telemetry packets
- build new test in CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6856c54c503c8326aa63056d89cd3944