### PR TITLE
Align NRF24 pin constants for TX/RX

### DIFF
--- a/mpu_send_test.cpp
+++ b/mpu_send_test.cpp
@@ -8,9 +8,9 @@
 #include <thread>
 
 #define TX_CE_PIN 27
-#define TX_CSN_PIN 10
+#define TX_CSN_PIN 0
 #define RX_CE_PIN 22
-#define RX_CSN_PIN 0
+#define RX_CSN_PIN 10
 
 static constexpr uint64_t GBS_ADDR_TX = 0xF0F0F0F0D2ULL;
 static constexpr uint64_t GBS_ADDR_RX = 0xF0F0F0F0E1ULL;


### PR DESCRIPTION
## Summary
- update `mpu_send_test.cpp` to use the common pin layout for TX/RX modules

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `./test/duplex_test` *(fails: Can't open device /dev/spidev1.0)*

------
https://chatgpt.com/codex/tasks/task_e_685701a9bfb4832681e84cfa3264670a