### PR TITLE
Improve simple_main range

### DIFF
--- a/src/simple_main.cpp
+++ b/src/simple_main.cpp
@@ -34,7 +34,8 @@ int main() {
     return 1;
   }
 
-  radio.configure(1, RadioDataRate::MEDIUM_RATE);
+  // Maximum range achieved using the lowest data rate
+  radio.configure(1, RadioDataRate::LOW_RATE);
   radio.setAddress(BASE_TX, BASE_RX);
 
   Mpu6050 sensor;


### PR DESCRIPTION
## Summary
- comment that low data rate is needed for maximum range
- configure radio at low data rate in `simple_main`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./test/duplex_test` *(fails: librf24.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685889844c4483269729c69b7fe171fc